### PR TITLE
fix similar(env) deprecation in 0.7

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -385,8 +385,7 @@ function lower(s::FileUnpacker,collection)
 end
 
 function adjust_env(env)
-    ret = similar(env)
-    merge!(ret,ENV)
+    ret = copy(ENV)
     merge!(ret,env) # s.env overrides ENV
     ret
 end


### PR DESCRIPTION
`similar(env::AbstractDict)` is deprecated in favor of `empty(env)` in 0.7 (JuliaLang/julia#25224).  There is no Compat support for this, it seems, but this particular call site could be changed to use `copy`.

(I noticed this in updating CMakeWrappers.jl)