### PR TITLE
test on Julia 1.0 and fix some deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ os:
 julia:
   - 0.6
   - 0.7
+  - 1.0
   - nightly
+matrix:
+  allow_failures:
+    - julia: 1.0
+    - julia: nightly
 notifications:
   email: false
 after_success:
-  - julia -e 'cd(Pkg.dir("BinDeps")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Codecov.process_folder())';
+  - julia -e 'if VERSION >= v"0.7-"; import Pkg; end; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 URIParser
 SHA
-Compat 0.65.1
+Compat 0.62

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 URIParser
 SHA
-Compat 0.62.0
+Compat 0.65.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,20 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.6
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: 1.0
+  - julia_version: nightly
 
 branches:
   only:
@@ -17,19 +28,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"BinDeps\"); Pkg.build(\"BinDeps\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"BinDeps\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Compat
 using Compat.Test, Compat.Unicode
 using BinDeps
+using Compat.Pkg
 
 if VERSION >= v"0.7.0-DEV.3382"
     using Libdl
@@ -28,7 +29,7 @@ BinDeps.debug("Cairo")
 let gv = glibc_version()
     if Compat.Sys.islinux()
         lddv = lowercase(readchomp(`ldd --version`))
-        if contains(lddv, "gnu") || contains(lddv, "glibc")
+        if occursin("gnu", lddv) || occursin("glibc", lddv)
             @test isa(gv, VersionNumber)
             @test gv >= v"1.0.0"
         else


### PR DESCRIPTION
x-ref: https://github.com/JuliaLang/METADATA.jl/pull/16899#issuecomment-413568001

Tests on Julia 1.0 are currently broken primarily because the BinDeps.jl tests try to build GSL.jl, but GSL hasn't been updated for Julia 1.0. Since it's better to know what the problem is, I've turned tests for v1.0 but marked them as allowed failures. 