### PR TITLE
Suggest possible remedy in error message

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -942,7 +942,7 @@ function satisfy!(dep::LibraryDependency, methods = defaults)
                 end
             end
             run(lower(generate_steps(dep,p,opts)))
-            !issatisfied(dep) && error("Provider $method failed to satisfy dependency $(dep.name)")
+            !issatisfied(dep) && error("Provider $method failed to satisfy dependency $(dep.name). Maybe you forgot to declare an alias in a library_dependency?")
             return p
         end
     end


### PR DESCRIPTION
When a library does not provide the dependency it claims to provide, suggest in the error message that and `alias` declaration in a `library_dependency` declaration might be missing.