### PR TITLE
Only use /sbin/ldconfig if it exists.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,25 @@
+name = "BinDeps"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.9.0"
+
+[deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[compat]
+Cairo = "0.5, 0.6"
+URIParser = "0.3.1, 0.4"
+julia = "1"
+
+[extras]
+Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+GSL = "92c85e6c-cbff-5e0c-80f7-495c94daaecd"
+Gumbo = "708ec375-b3d6-5a57-a7ce-8257bf98657a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Cairo", "Compat", "GSL", "Gumbo", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,9 @@ end
 
 Pkg.build("Cairo")  # Tests apt-get code paths
 using Cairo
-Pkg.build("HttpParser")  # Tests build-from-source code paths
-using HttpParser
+# Disabled: HttpParser isn't available in Julia 1.0
+#Pkg.build("HttpParser")  # Tests build-from-source code paths
+#using HttpParser
 Pkg.build("GSL")
 using GSL
 


### PR DESCRIPTION
On some platforms, /sbin/ldconfig does not exist, e.g. NixOS [0]. This patch skips the /sbin/ldconfig call if the path does not exist.

[0] https://nixos.org/nixos