### PR TITLE
Fix on systems without ldconfig, such as NixOS

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -395,7 +395,12 @@ elseif Compat.Sys.islinux()
     global read_sonames
     function read_sonames()
         empty!(sonames)
-        for line in eachline(`/sbin/ldconfig -p`)
+        ldconfig = try
+          eachline(`/sbin/ldconfig -p`)
+        catch
+          eachline(`true`)
+        end
+        for line in ldconfig
             VERSION < v"0.6" && (line = chomp(line))
             m = match(r"^\s+([^ ]+)\.so[^ ]* \(([^)]*)\) => (.+)$", line)
             if m !== nothing
@@ -415,7 +420,12 @@ elseif Compat.Sys.islinux()
 else
     function read_sonames()
         empty!(sonames)
-        for line in eachline(`/sbin/ldconfig -r`)
+        ldconfig = try
+          eachline(`/sbin/ldconfig -r`)
+        catch
+          eachline(`true`)
+        end
+        for line in ldconfig
             m = match(r"^\s+\d+:-l([^ ]+)\.[^. ]+ => (.+)$", line)
             if m !== nothing
                 sonames["lib" * m[1]] = m[2]


### PR DESCRIPTION
This has been broken for a while. ~~Can someone make sure it still works on other systems?~~  (there's a test suite, lol) On systems without ldconfig, it searches LD_LIBRARY_PATH (as it did before with a 
dummy ldconfig).

EDIT: #383 exists...