### PR TITLE
fixes to fail to apt-get install

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -450,8 +450,8 @@ function generate_steps(dep::LibraryDependency,h::AptGet,opts)
     end
     sudo = get(opts, :sudo, has_sudo[]) ? `sudo` : ``
     @build_steps begin
-        println("Installing dependency $(h.package) via `$(sudoname(sudo))apt-get install $(h.package)`:")
-        `$sudo apt-get install $(h.package)`
+        println("Installing dependency $(h.package) via `$(sudoname(sudo))apt-get install -y $(h.package)`:")
+        `$sudo apt-get install -y $(h.package)`
         reread_sonames
     end
 end


### PR DESCRIPTION
apt-get require to type yes.
add -y option to skip confirm.