### PR TITLE
Add sbin paths to PATH

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -383,6 +383,12 @@ if Sys.iswindows() || Sys.isapple()
         have_sonames[] = true
     end
 elseif Sys.islinux()
+    # Some Linux distros do not expose executables from /sbin and /usr/sbin via PATH.
+    # If that's the case, we add these paths here explicitly
+    if isnothing(Sys.which("ldconfig"))
+        ENV["PATH"] *= ":/usr/local/sbin:/usr/sbin:/sbin"
+    end
+
     let ldconfig_arch = Dict(:i386 => "x32",
                              :i387 => "x32",
                              :i486 => "x32",

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -396,15 +396,11 @@ elseif Sys.islinux()
     function read_sonames()
         empty!(sonames)
 
-        # Some Linux distros do not expose executables from /sbin and /usr/sbin via PATH.
-        # If that's the case, we add these paths here explicitly
-        if isnothing(Sys.which("ldconfig"))
-            ldcfg_path = ENV["PATH"] * ":/usr/local/sbin:/usr/sbin:/sbin"
-            lines_ldconfig = withenv("PATH" => ldcfg_path) do
-                eachline(`ldconfig -p`)
-            end
-        else
-            lines_ldconfig = eachline(`ldconfig -p`)
+        # Some Linux distros do not expose executables from /sbin and /usr/sbin via PATH,
+        # so we append these here explicitly
+        ldconfig_path = ENV["PATH"] * ":/usr/local/sbin:/usr/sbin:/sbin"
+        lines_ldconfig = withenv("PATH" => ldconfig_path) do
+            eachline(`ldconfig -p`)
         end
         for line in lines_ldconfig
             VERSION < v"0.6" && (line = chomp(line))


### PR DESCRIPTION
Adds `/sbin` and related paths to `PATH` in case `ldconfig` cannot be found without them. Fixes #415 for Debian and similar distros, which do not expose `/sbin` inside the `PATH` for non-root users by default.
